### PR TITLE
Fix missing focus bar in ThresholdUI

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "ThresholdUI",
        "title": "UI for ThresholdRPG",
        "description": "Threshold RPG UI",
-       "version": "4.0.0",
+       "version": "4.1.0",
        "author": "Gesslar",
        "icon": "griffon-right.jpg",
        "dependencies": "",

--- a/src/scripts/Event_Handlers.lua
+++ b/src/scripts/Event_Handlers.lua
@@ -12,9 +12,7 @@ ThresholdUI.EventHandlers = ThresholdUI.EventHandlers or {
     {"gmcp.Char.Status", "Inactive", f[[ThresholdUI:DoInactiveTimer]]},
     {"ThresholdUI.ToggleHealTick", nil, f[[ThresholdUI:ToggleHealTick]]},
     {"ThresholdUI.ToggleTimeBox", nil, f[[ThresholdUI:ToggleTimeBox]]},
-    {"gmcp.Char.Feedback", nil, f[[ThresholdUI:UpdateFeedback]]},
-    {"ThresholdUI.FeedbackToggle", nil, f[[ThresholdUI:FeedbackToggle]]},
-    {"gmcp.Char.Feedback", nil, f[[ThresholdUI:UpdateFeedback]]},
+    {"gmcp.Char.Feedback", "Feedback", f[[ThresholdUI:UpdateFeedback]]},
     {"ThresholdUI.FeedbackToggle", nil, f[[ThresholdUI:FeedbackToggle]]},
 }
 

--- a/src/scripts/GUI/Feedback.lua
+++ b/src/scripts/GUI/Feedback.lua
@@ -24,9 +24,9 @@ ThresholdUI.FeedbackBox:hide()
 
 function ThresholdUI:FeedbackToggle()
     -- Inactive bar is not being shown
-    if not resumeNamedTimer(self.AppName, self.AppName .. ".InactiveTimer") then
+    if self.InactiveContainer.hidden then
         -- We have no feedback: hide
-        if not gmcp.Char.Feedback or not #gmcp.Char.Feedback then
+        if not gmcp.Char or not gmcp.Char.Feedback or not #gmcp.Char.Feedback then
             self.FeedbackBox:hide()
             setBorderBottom(self.metrics.height)
         -- We have feedback: show
@@ -39,8 +39,10 @@ function ThresholdUI:FeedbackToggle()
         self.FeedbackBox:hide()
     end
 end
+ThresholdUI:FeedbackToggle()
 
 function ThresholdUI:UpdateFeedback()
+    if self.FeedbackBox.hidden then self:FeedbackToggle() end
     for _, v in ipairs(self.FeedbackLabels) do
         local label = "Feedback_" .. Capitalize(v)
         local found = false


### PR DESCRIPTION
This pull request fixes the issue of the missing focus bar for psion/psion templars in ThresholdUI 4.0.0. The changes include modifying the event handlers and functions related to feedback display. The focus bar will now be properly shown when there is feedback available.