### PR TITLE
Bump version to 4.3.0

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
        "package": "ThresholdUI",
        "title": "UI for ThresholdRPG",
        "description": "Threshold RPG UI",
-       "version": "4.1.0",
+       "version": "4.3.0",
        "author": "Gesslar",
        "icon": "griffon-right.jpg",
        "dependencies": "",


### PR DESCRIPTION
### TL;DR

Bumped ThresholdUI version from 4.1.0 to 4.3.0.

### What changed?

Updated the version number in the package metadata from 4.1.0 to 4.3.0, indicating a minor version update for the ThresholdRPG UI.

### How to test?

- Verify the package loads correctly with the new version number
- Check that all UI functionality works as expected
- Confirm the version number appears correctly in any version displays or about screens

### Why make this change?

To reflect recent feature additions and improvements to the ThresholdUI package that warrant a version increment to 4.3.0.